### PR TITLE
Handle trivial input better in 14.longest-common-prefix.jl

### DIFF
--- a/src/problems/14.longest-common-prefix.jl
+++ b/src/problems/14.longest-common-prefix.jl
@@ -48,7 +48,7 @@ using LeetCode
 function longest_common_prefix(strs::Vector{String})::String
     s1, s2 = minimum(strs), maximum(strs)
     pos = findfirst(i -> s1[i] != s2[i], 1:length(s1))
-    return isnothing(pos) ? "" : s1[1:(pos - 1)]
+    return isnothing(pos) ? s1 : s1[1:(pos - 1)]
 end
 
 ## @lc code=end

--- a/test/problems/14.longest-common-prefix.jl
+++ b/test/problems/14.longest-common-prefix.jl
@@ -2,4 +2,7 @@
     @test longest_common_prefix(["flower", "flow", "flight"]) == "fl"
     @test longest_common_prefix(["dog", "racecar", "car"]) == ""
     @test longest_common_prefix(["reflower", "flow", "flight"]) == ""
+    @test longest_common_prefix(["abc"]) == "abc"
+    @test longest_common_prefix(fill("abc", 5)) == "abc"
+    @test longest_common_prefix(fill("", 4)) == ""
 end


### PR DESCRIPTION
This change makes the algorithm able to correctly handle cases where there is only one input string or where all input strings are equal.

e.g.
```julia
using Test, LeetCode

@test lcp(["abc"]) == "abc"
@test lcp(["abc", "abc"]) == "abc"
```
